### PR TITLE
feat(#4): ErrorBoundary, useErrorBoundary

### DIFF
--- a/packages/react-shared/src/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/react-shared/src/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ErrorBoundary, useErrorBoundary } from ".";
+import { useEffect } from "react";
+
+describe("ErrorBoundary", () => {
+  const ErrorComponent = () => {
+    useEffect(() => {
+      throw new Error("Oh no");
+    }, []);
+
+    return <></>;
+  };
+
+  beforeAll(() => {
+    jest.spyOn(console, "error").mockImplementation(() => null);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("children에서 throw한 에러를 캐치합니다.", () => {
+    expect(() =>
+      render(
+        <ErrorBoundary>
+          <ErrorComponent />
+        </ErrorBoundary>
+      )
+    ).toThrow();
+  });
+
+  test("fallback이 존재하면 에러를 캐치한 뒤 fallback을 랜더링 합니다.", () => {
+    render(
+      <ErrorBoundary fallback={<div>error</div>}>
+        <ErrorComponent />
+      </ErrorBoundary>
+    );
+
+    const errorText = screen.getByText("error");
+
+    expect(errorText).toBeInTheDocument();
+  });
+
+  test("onError가 존재하면 에러를 캐치한 뒤 onError를 실행합니다.", () => {
+    const callback = jest.fn();
+
+    render(
+      <ErrorBoundary onError={callback} fallback={<div>error</div>}>
+        <ErrorComponent />
+      </ErrorBoundary>
+    );
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  describe("useErrorBoundary를 사용하면 ErrorBoundary가 캐치할 수 있는 에러를 throw할 수 있습니다.", () => {
+    test("Event에서 throw 한 뒤 catch할 수 있습니다.", () => {
+      const EventErrorComponent = () => {
+        const throwError = useErrorBoundary();
+        return (
+          <button role="button" onClick={() => throwError(new Error("error"))}>
+            error
+          </button>
+        );
+      };
+
+      render(
+        <ErrorBoundary fallback={<>Error!</>}>
+          <EventErrorComponent />
+        </ErrorBoundary>
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      const errorMessage = screen.getByText("Error!");
+
+      expect(errorMessage).toBeInTheDocument();
+    });
+
+    test("async에서 throw 한 뒤 catch할 수 있습니다.", () => {
+      const AsyncErrorComponent = () => {
+        const throwError = useErrorBoundary();
+
+        setTimeout(() => {
+          throwError(new Error("error"));
+        }, 0);
+
+        return <></>;
+      };
+
+      render(
+        <ErrorBoundary fallback={<>Error!</>}>
+          <AsyncErrorComponent />
+        </ErrorBoundary>
+      );
+
+      waitFor(() => {
+        const errorMessage = screen.getByText("Error!");
+        expect(errorMessage).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/react-shared/src/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/react-shared/src/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,79 @@
+import { Component, ErrorInfo } from "react";
+
+type Fallback =
+  | React.ReactNode
+  | (({
+      error,
+      errorInfo,
+      resetError,
+    }: {
+      error?: Error;
+      errorInfo?: ErrorInfo;
+      resetError: () => unknown;
+    }) => React.ReactNode);
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: Fallback;
+
+  onError?: (error: Error, errorInfo: ErrorInfo) => unknown;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+  errorInfo?: ErrorInfo;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  async componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.setState({
+      hasError: true,
+      error,
+      errorInfo,
+    });
+    this.props.onError?.(error, errorInfo);
+  }
+
+  private resetError = () => {
+    this.setState({
+      hasError: false,
+      error: undefined,
+      errorInfo: undefined,
+    });
+  };
+
+  private renderFallback = (fallback: Fallback) => {
+    if (typeof fallback === "function") {
+      return fallback({
+        error: this.state.error,
+        errorInfo: this.state.errorInfo,
+        resetError: this.resetError,
+      });
+    }
+    return fallback;
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.renderFallback(this.props.fallback);
+      } else {
+        throw this.state.error;
+      }
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/react-shared/src/ErrorBoundary/index.tsx
+++ b/packages/react-shared/src/ErrorBoundary/index.tsx
@@ -1,0 +1,2 @@
+export { ErrorBoundary } from "./ErrorBoundary";
+export { useErrorBoundary } from "./useErrorBoundary";

--- a/packages/react-shared/src/ErrorBoundary/useErrorBoundary.ts
+++ b/packages/react-shared/src/ErrorBoundary/useErrorBoundary.ts
@@ -1,0 +1,11 @@
+import { useState } from "react";
+
+export const useErrorBoundary = () => {
+  const [error, setError] = useState<Error>();
+
+  if (error) {
+    throw error;
+  }
+
+  return setError;
+};

--- a/packages/react-shared/tsconfig.json
+++ b/packages/react-shared/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
+    "esModuleInterop": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
ErrorBoundary : 자식에서 throw한 error를 catch하는 컴포넌트

useErrorBoundary : ErrorBoundery가 catch할 수 없는 에러 (비동기, 이벤트)에서 ErrorBoundary가 catch 가능한 Error를 throw하는 훅

## 구현 사항

- [x] ErrorBoundary
- [x] useErrorBoundary

## 구현 테스트코드, 이미지

![image](https://github.com/ATeals/frontend-monorepo/assets/125727432/b17a087d-04e0-470b-9dee-93fed8c17ab5)
